### PR TITLE
Fix code block indentation in CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -100,7 +100,7 @@ This plugin offers easy extensibility for tracking new statistics. Look through 
 
         // add the statistics to the controller
         statController.add(timeSpentStat);
-    ```
+        ```
 
 ---
 


### PR DESCRIPTION
The rendered markdown file displayed a blank code block after the one desired to be shown. This has been removed by fixing the indentation.