### PR TITLE
Fix #9: Icon to reset statistics does not display in versions older than v0.4.3

### DIFF
--- a/src/info.js
+++ b/src/info.js
@@ -1,5 +1,5 @@
 export const name = "openrct2-statistics";
-export const version = "1.1.0";
+export const version = "1.1.1";
 export const type = "intransient";
 export const license = "MIT";
 

--- a/src/window/windowReset.ts
+++ b/src/window/windowReset.ts
@@ -13,6 +13,8 @@ import {
 import { StatController } from "../objects/StatController";
 
 export function getResetWidget(sc: StatController): WidgetCreator<FlexiblePosition> {
+    const image = context.apiVersion < 65 ? 5165 : context.getIcon("reload");
+
     const parkNameFormat = (name: string) => `Reset Statistics for "${name}"`;
     let parkName = store(parkNameFormat(events.parkName.get()));
     events.parkName.subscribe((newName) => parkName.set(parkNameFormat(newName)));
@@ -27,7 +29,7 @@ export function getResetWidget(sc: StatController): WidgetCreator<FlexiblePositi
         content: [
             horizontal([
                 button({
-                    image: "reload",
+                    image: image,
                     width: "25px",
                     height: "25px",
                     onClick: () => resetGenericStatistics(sc),
@@ -36,7 +38,7 @@ export function getResetWidget(sc: StatController): WidgetCreator<FlexiblePositi
             ]),
             horizontal([
                 button({
-                    image: "reload",
+                    image: image,
                     width: "25px",
                     height: "25px",
                     visibility: isParkWidgetVisible,


### PR DESCRIPTION
Fixes #9.

If `context.apiVersion` is less than 65 (the version which introduced the `context.getIcon()` method), then the icon for Demolish (5165) is used instead. The integer value corresponding with this sprite doesn't change due to it being in base-game G1.

While v0.4.2 does have the preferred icon for resetting in G2, the additional icon doesn't correspond with a change in the plugin api which would be easy to check. Also, that would further add complexity to the code for just one version of the game, which likely doesn't have very many players currently.