### PR TITLE
Add statistic for drowned guests

### DIFF
--- a/src/startup.ts
+++ b/src/startup.ts
@@ -3,6 +3,7 @@ import * as window from "./window/window";
 import * as windowWarning from "./window/windowWarning";
 import { StatController } from "./objects/StatController";
 import { timeSpentStatistic } from "./statistics/timeSpent";
+import { guestsDrownedStatistic } from "./statistics/guestsDrowned";
 
 /**
  * The entry point for this plugin. Should initialize any tracking of statistics, and if the ui
@@ -14,13 +15,10 @@ export function startup() {
     // Events for ease of tracking game state
     events.initialize();
 
-    // Stat to track how much time has been spent in the game
-    const timeSpentStat = timeSpentStatistic();
-
-    // prettier-ignore
-    // Setup the container for statistics to track
+    // Setup the statistics to track and their container
     const statController = new StatController()
-        .add(timeSpentStat);
+        .add(timeSpentStatistic())
+        .add(guestsDrownedStatistic());
 
     if (typeof ui !== "undefined") {
         windowWarning.initialize();

--- a/src/statistics/guestsDrowned.ts
+++ b/src/statistics/guestsDrowned.ts
@@ -1,0 +1,37 @@
+import { Statistic } from "../objects/Statistic";
+
+const STATISTIC_KEY = "guestsDrowned";
+const STATISTIC_TITLE = "Guests Drowned in";
+
+type GuestsDrownedStat = number;
+
+const subscribeToGuestDrowning = (
+    updatedValueCallback: (additionalGuests: GuestsDrownedStat) => void,
+) => {
+    context.subscribe("guest.drown", (_) => {
+        updatedValueCallback(1);
+    });
+};
+
+const accumulateGuests = (newVal: GuestsDrownedStat, existingVal: GuestsDrownedStat) => {
+    return existingVal + newVal;
+};
+
+const formatDisplay = (totalGuests: GuestsDrownedStat) => {
+    return totalGuests.toString();
+};
+
+export const guestsDrownedStatistic = () => {
+    const key = STATISTIC_KEY;
+    const title = STATISTIC_TITLE;
+    const resetValue = 0;
+
+    return new Statistic(
+        key,
+        title,
+        resetValue,
+        subscribeToGuestDrowning,
+        accumulateGuests,
+        formatDisplay,
+    );
+};


### PR DESCRIPTION
Adds a statistic for how many guests the player has let drown in their parks. No real way to discern whether it's because they fell after a path was deleted or if it was due to them being plucked by the pliers of the sky, but either way, this will track how many bad swimmers have met their maker (should the linked PR be merged).

---

Waiting On:

- [ ] OpenRCT2/OpenRCT2#21574
- [ ] #7

To Do:

- [ ] Set minApiVersion for `guestDrownedStatistic`
- [ ] Update `targetApiVersion` in project, ensuring links to `openrct2.d.ts` include the `guest.drown` hook
- [ ] Update plugin version