### PR TITLE
Add information needed to run the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ A way for you to track your in-game statistics (overall and per-park) such as:
 
 ...that's all you need, right?
 
+## Getting the plugin
+
+> [!IMPORTANT]
+> Requires OpenRCT2 v0.4.0 or newer.
+
+Download the `.js` file from the [latest release](https://github.com/KatieZeldaKat/openrct2-statistics/releases/latest) and place it in the "plugin" folder. This can be found by opening OpenRCT2 and selecting "Open custom content folder" under the toolbox in the main menu.
+
 ## Future development
 
 Okay, so there might be other statistics you would want to track in-game. These have not been implemented yet. Some ideas which come to mind:


### PR DESCRIPTION
Resolves #8.

Adds information to the `README` to specify the minimum OpenRCT2 version as well as how to install the plugin.