### PR TITLE
Update CI for forked repos

### DIFF
--- a/.github/workflows/prettier-ci.yml
+++ b/.github/workflows/prettier-ci.yml
@@ -12,7 +12,8 @@ jobs:
               uses: actions/checkout@v4
               with:
                   fetch-depth: 0
-                  ref: ${{ github.head_ref }}
+                  ref: ${{ github.event.pull_request.head.ref }}
+                  repository: ${{ github.event.pull_request.head.repo.full_name }}
                   persist-credentials: false
 
             - name: Prettify code


### PR DESCRIPTION
CI would fail to run due to the checkout not working on forked repositories. This makes the checks useless for outside pull requests. This change should fix it, though it will need testing.