### PR TITLE
Update prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,0 @@
-# Ignore markdown while issue is open: https://github.com/prettier/prettier/issues/5019
-*.md

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ A way for you to track your in-game statistics (overall and per-park) such as:
 
 ## Getting the plugin
 
-> [!IMPORTANT] Requires OpenRCT2 v0.4.0 or newer.
+<!-- prettier-ignore -->
+> [!IMPORTANT]
+> Requires OpenRCT2 v0.4.0 or newer.
 
 Download the `.js` file from the [latest release](https://github.com/KatieZeldaKat/openrct2-statistics/releases/latest) and place it in the "plugin" folder. This can be found by opening OpenRCT2 and selecting "Open custom content folder" under the toolbox in the main menu.
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ A way for you to track your in-game statistics (overall and per-park) such as:
 
 ## Getting the plugin
 
-> [!IMPORTANT]
-> Requires OpenRCT2 v0.4.0 or newer.
+> [!IMPORTANT] Requires OpenRCT2 v0.4.0 or newer.
 
 Download the `.js` file from the [latest release](https://github.com/KatieZeldaKat/openrct2-statistics/releases/latest) and place it in the "plugin" folder. This can be found by opening OpenRCT2 and selecting "Open custom content folder" under the toolbox in the main menu.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -53,7 +53,7 @@ This plugin offers easy extensibility for tracking new statistics. Look through 
 
     ```ts
     const subscribeToTimePassing = (
-        updatedValueCallback: (addedTime: TimeSpentStat) => void
+        updatedValueCallback: (addedTime: TimeSpentStat) => void,
     ) => {
         context.setInterval(() => {
             updatedValueCallback(1);
@@ -77,7 +77,7 @@ This plugin offers easy extensibility for tracking new statistics. Look through 
         // in practice, newAmountOfTimePassed will always be 1 (for 1 second)
         function accumulateSecond(
             newAmountOfTimePassed: TimeSpendStat,
-            existingVal: TimeSpendStat
+            existingVal: TimeSpendStat,
         ) {
             return existingVal + newAmountOfTimePassed;
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "@rollup/plugin-terser": "^0.4.0",
                 "@rollup/plugin-typescript": "^11.0.0",
                 "nodemon": "^3.0.1",
-                "prettier": "3.2.5",
+                "prettier": "3.4.1",
                 "rollup": "^3.15.0",
                 "tslib": "^2.5.0"
             }
@@ -590,9 +590,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.2.5",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
-            "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.1.tgz",
+            "integrity": "sha512-G+YdqtITVZmOJje6QkXQWzl3fSfMxFwm1tjTyo9exhkmWSqC4Yhd1+lug++IlR2mvRVAxEDDWYkQdeSztajqgg==",
             "dev": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "@rollup/plugin-terser": "^0.4.0",
         "@rollup/plugin-typescript": "^11.0.0",
         "nodemon": "^3.0.1",
-        "prettier": "3.2.5",
+        "prettier": "3.4.1",
         "rollup": "^3.15.0",
         "tslib": "^2.5.0"
     },


### PR DESCRIPTION
The [prettier issue for `.md` files](https://github.com/prettier/prettier/issues/5019) is now fixed. As such, markdown files no longer need to be ignored.

This only affects development. No new release needed.